### PR TITLE
Fixed markdown link typo pointing to deploy-keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 
     `baseurl: "/your-repo-name"`
 
-4. [Follow these instructions to create an ssh-deploy key]((https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys)).  Make sure you **select Allow write access** when adding this key to your GitHub account.
+4. [Follow these instructions to create an ssh-deploy key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys).  Make sure you **select Allow write access** when adding this key to your GitHub account.
 
 5. [Follow these instructions to upload your deploy key](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets) as an encrypted secret on GitHub.  Make sure you name your key `SSH_DEPLOY_KEY`.
 


### PR DESCRIPTION
The link pointing to github/deploy-keys had one parenthesis too much - preventing the markdown link from working.