### PR TITLE
Enable Comments on Blog Posts via Utterances

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Additional metadata is optional and allows you to set custom [front matter](http
 
 ### Enabling Comments
 
-Blog posting is powered by [Utterances](https://github.com/utterance/utterances) which is an open-source and ad-free way of implementing comments.  All comments are stored in issues on your blog's GitHub repo.  You can turn this on setting `comments` to  `true`.  This defaults to `false`.
+Blog posting is powered by [Utterances](https://github.com/utterance/utterances), an open-source and ad-free way of implementing comments.  All comments are stored in issues on your blog's GitHub repo.  You can turn this on setting `comments` to  `true`.  This defaults to `false`.
 
 ### Hide Input/Output Cells
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ Additional metadata is optional and allows you to set custom [front matter](http
 
 Blog posting is powered by [Utterances](https://github.com/utterance/utterances), an open-source and ad-free way of implementing comments.  All comments are stored in issues on your blog's GitHub repo.  You can turn this on setting `comments` to  `true`.  This defaults to `false`.
 
+To enable comments with [Utterances](https://github.com/utterance/utterances) you will need to do the following:
+
+  - Make sure the repo is public, otherwise your readers will not be able to view the issues/comments.
+  - Make sure the [utterances app](https://github.com/apps/utterances) is installed on the repo, otherwise users will not be able to post comments.
+  - If your repo is a fork, navigate to it's settings tab and confirm the issues feature is turned on.
+
 ### Hide Input/Output Cells
 
 Place the comment `#hide` at the beginning of a code cell and it wil **hide both the input and the output** of that cell. If you only want to hide just the input or the output, use the `hide input` [Jupyter Extension](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/hide_input/readme.html)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ _See the [this section](#Writing-Blog-Posts-With-Jupyter) below for more details
       - [Configure Title & Summary](#configure-title-summary)
       - [Table of Contents](#table-of-contents)
       - [Colab & GitHub Badges](#colab-github-badges)
+      - [Enabling Comments](#enabling-comments)
       - [Hide Input/Output Cells](#hide-inputoutput-cells)
       - [Collapsable Code Cells](#collapsable-code-cells)
       - [Embedded Twitter and YouTube Content](#embedded-twitter-and-youtube-content)
@@ -97,6 +98,7 @@ Create a markdown cell at the beginning of the notebook with the following conte
   - toc: false
   - branch: master
   - badges: true
+  - comments: true
   - metadata_key1: metadata_value1
   - metadata_key2: metadata_value2
   ```
@@ -112,6 +114,10 @@ Additional metadata is optional and allows you to set custom [front matter](http
 #### Colab & GitHub Badges
   -  The `branch` field is used to optionally render a link your notebook to Colab and GitHub in your blog post post. It'll default to `master` if you don't specify it in the notebook.
   - If you do not want to show Colab / GitHub badges on your blog post (perhaps because your repo is private and the links would be broken) set `badges` to `false`.  This defaults to `true`
+
+### Enabling Comments
+
+Blog posting is powered by [Utterances](https://github.com/utterance/utterances) which is an open-source and ad-free way of implementing comments.  All comments are stored in issues on your blog's GitHub repo.  You can turn this on setting `comments` to  `true`.  This defaults to `false`.
 
 ### Hide Input/Output Cells
 

--- a/_includes/utterances.html
+++ b/_includes/utterances.html
@@ -1,0 +1,9 @@
+<!-- from https://github.com/utterance/utterances -->
+<script src="https://utteranc.es/client.js"
+        repo="{{ site.github_username }}/{{ site.github_repo | default: site.baseurl | remove: "/" }}"
+        issue-term="title"
+        label="blogpost-comment"
+        theme="github-light"
+        crossorigin="anonymous"
+        async>
+</script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,39 @@
+---
+layout: default
+---
+<article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
+
+  <header class="post-header">
+    <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
+    <p class="post-meta">
+      {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+        {{ page.date | date: date_format }}
+      </time>
+      {%- if page.modified_date -%}
+        ~ 
+        {%- assign mdate = page.modified_date | date_to_xmlschema -%}
+        <time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">
+          {{ mdate | date: date_format }}
+        </time>
+      {%- endif -%}
+      {%- if page.author -%}
+        • {% for author in page.author %}
+          <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+            <span class="p-author h-card" itemprop="name">{{ author }}</span></span>
+            {%- if forloop.last == false %}, {% endif -%}
+        {% endfor %}
+      {%- endif -%}</p>
+  </header>
+
+  <div class="post-content e-content" itemprop="articleBody">
+    {{ content }}
+  </div>
+  {%- if page.comments -%}
+    {%- include utterances.html -%}
+  {%- endif -%}
+  {%- if site.disqus.shortname -%}
+    {%- include disqus_comments.html -%}
+  {%- endif -%}
+  <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
+</article>

--- a/_notebooks/test.ipynb
+++ b/_notebooks/test.ipynb
@@ -8,7 +8,8 @@
     "> A demonstration of fastpages blog posts with Jupyter notebooks.\n",
     "\n",
     "- toc: true \n",
-    "- badges: true"
+    "- badges: true\n",
+    "- comments: true"
    ]
   },
   {

--- a/_notebooks/test.ipynb
+++ b/_notebooks/test.ipynb
@@ -34,6 +34,7 @@
     "\n",
     "- Setting `toc: true` will automatically generate a table of contents\n",
     "- Setting `badges: true` will automatically include GitHub and Google Colab links to your notebook.\n",
+    "- Setting `comments: true` will enable commenting on your blog post, powered by [utterances](https://github.com/utterance/utterances).\n",
     "\n",
     "More details and options for front matter can be viewed on the notebook section of the [README](https://github.com/fastai/fastpages#Writing-Blog-Posts-With-Jupyter)."
    ]


### PR DESCRIPTION
Summary of changes:

- Utilizing [Utterances](https://github.com/utterance/utterances) an open-source project that uses GitHub issues to store comments on your blog post.  It is ad-free, you own your data, and its free. 
- Updated `/_layouts/post.html` to allow for comments
- Updated README
- Updated notebook to turn this option on for demo purposes