### PR TITLE
Fix Setup Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ _See the [this section](#Writing-Blog-Posts-With-Jupyter) below for more details
 
 ## Setup Instructions
 
-1. Click the [![](https://img.shields.io/static/v1?label=&message=Use%20this%20template&color=brightgreen&style=flat)](https://github.com/fastai/fastpages/generate) button to create a copy of this repo in your account.
+1.  Generate a copy of this repo by clicking [on this link](https://github.com/fastai/fastpages/generate).
 
-2. **GitHub Actions will automatically open a PR** on your new repository ~ 30 seconds after setting it up from the template.  Follow the instructions in that PR to continue.
+2. **GitHub Actions will automatically open a PR** on your new repository ~ 30 seconds after the copy is created.  Follow the instructions in that PR to continue.
 
 
 ## Writing Blog Posts With Jupyter

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -10,3 +10,17 @@ https://{_username_}.github.io/{_repo_name_}/
 
 
 _powered by [fastpages](https://github.com/fastai/fastpages)_
+
+
+## What To Do Next?
+
+Great!  You have setup your repo.  Now its time to start writing content.  Some helpful links:
+
+- [Writing Blogs With Jupyter](https://github.com/fastai/fastpages#writing-blog-posts-with-jupyter)
+
+- [Writing Blogs With Markdown](https://github.com/fastai/fastpages#writing-blog-posts-with-markdown)
+
+- [Writing Blog Posts With Word](https://github.com/fastai/fastpages#writing-blog-posts-with-microsoft-word)
+
+
+Please use the [nbdev & blogging channel](https://forums.fast.ai/c/fastai-users/nbdev/48) in the fastai forums for any questions or feature requests.

--- a/_setup_pr_template.md
+++ b/_setup_pr_template.md
@@ -2,17 +2,12 @@ Hello :wave: @{_username_}!  Thank you for using fastpages!
 
 ## Before you merge this PR
 
-1. [Follow these instructions to create an ssh-deploy key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys).  Make sure you **select Allow write access** when adding this key to your GitHub account.
+1. Create an ssh key-pair.  Open <a href="https://8gwifi.org/sshfunctions.jsp" target="_blank">this utility</a>. Select: `RSA` and `4096` and leave `Passphrase` blank.  Click the blue button `Generate-SSH-Keys`.
 
-2. [Follow these instructions to upload your deploy key](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets) as an encrypted secret on GitHub.  Make sure you name your key `SSH_DEPLOY_KEY`.  Note: The deploy key secret is your **private key** (NOT the public key).
+2. Navigate to <a href="https://github.com/{_username_}/{_repo_name_}/settings/secrets" target="_blank">this link</a> and click `Add a new secret`.  Copy and paste the **Private Key** into the `Value` field. In the `Name` field, name the secret `SSH_DEPLOY_KEY`.  Finally, make sure you click the checkbox next to `Allow write access` and click `Add key` to save the key.  
 
+3. Navigate to <a href="https://github.com/{_username_}/{_repo_name_}/settings/keys" target="_blank">this link</a> and click the `Add deploy key` button.  Paste your **Public Key** from step 1 into the `Key` box.  In the `Title`, name the key anything you want, for example `fastpages-key`.
 
-### Summary of changes made in this PR
-
-- `README.md`: changed badge URLs to reflect this repository & removed fastpages instructions.
-- `_config.yml`: corrected the `github_username`, `baseurl`, `github_repo`, and `url` parameters to reflect this repository.
-- Removed extreanous files that are used for the maintenance of fastpages and not useful for this repo.
-- Saved the instructions in this PR to `_setup_pr_template.md` in the root of your repository for easy reference at a later time.
 
 ### What to Expect After Merging This PR
 


### PR DESCRIPTION
Summary of Changes

- Better SSH Keygen instructions 
- Removed button from README
- Removed "What this PR Does" from PR Message, and also links to GitHub docs b/c they were confusing.
- Added direct links to settings screens in PR
- Added "What to Do Next" in destination README.

Note: I made links in the PR "open in a new tab" via `<a target="_blank">` tags to further attempt and make this a smooth experience.

This is ready for review, @jph00 

Unfortunately, that annoying banner at the top of the repo is a bug, which I have filed internally.

This PR closes https://github.com/fastai/fastpages/issues/39 and https://github.com/fastai/fastpages/issues/57