### PR TITLE
Make nbdev summaries == descriptions for blog posts, and display them

### DIFF
--- a/_action_files/fastpages.tpl
+++ b/_action_files/fastpages.tpl
@@ -4,7 +4,7 @@
                     "raw_mimetypes", "global_content_filter"] -%}
 ---
 {%- for k in resources |reject("in", internals) %}
-{{ k }}: {{ resources[k] |replace(':', '') }}
+{% if k == "summary" and "description" not in resources %}description{% else %}{{ k }}{% endif %}: {{ resources[k] |replace(':', '') }}
 {%- endfor %}
 layout: notebook
 ---

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,6 +5,9 @@ layout: default
 
   <header class="post-header">
     <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
+    {%- if page.description -%}
+    <p>{{ page.description | escape }}</p>
+    {%- endif -%}
     <p class="post-meta">
       {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
       <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
   <header class="post-header">
     <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
     {%- if page.description -%}
-    <p>{{ page.description | escape }}</p>
+    <p class="page-description">{{ page.description | escape }}</p>
     {%- endif -%}
     <p class="post-meta">
       {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -308,3 +308,8 @@ h5:hover .anchor-link,
 h6:hover .anchor-link {
   opacity: 1;
 }
+
+.page-description {
+  color: #585858;
+  font-size: 120%;
+}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -311,5 +311,5 @@ h6:hover .anchor-link {
 
 .page-description {
   color: #585858;
-  font-size: 120%;
+  font-size: 110%;
 }


### PR DESCRIPTION
nbdev has summary field denoted like this

```
# Title
> summary
-metadata-key: metadata-value
```

The summary gets displayed on the docs like this 

![image](https://user-images.githubusercontent.com/1483922/74995746-997f1180-5406-11ea-99b1-2c87d7bd57fc.png)

Up until now, the summary was dissapearing in blog posts, **which is now fixed:**

![image](https://user-images.githubusercontent.com/1483922/74996311-1363ca80-5408-11ea-8de7-b05af5fbe23b.png)


Furthermore, if a user does not have a 
`description`  but has a `summary` tag in their front matter, then the summary is automatically substituted in for the `description` which is used by search engines and social media to display a small blurb about your page, and overrides the global description for your website in `_config.yaml`

cc: @jph00 / @sgugger aligning with nbdev conventions as much as possible.