### PR TITLE
replace add_embedded_links with external configuration in settings.ini

### DIFF
--- a/_action_files/nb2post.py
+++ b/_action_files/nb2post.py
@@ -13,25 +13,12 @@ def _nb2htmlfname(nb_path, dest=None):
     if dest is None: dest = Config().doc_path
     return Path(dest)/fname
 
-# Add embedded links for youtube and twitter
-def add_embedded_links(cell):
-    "Convert block quotes to embedded links in `cell`"
-    _styles = ['youtube', 'twitter']
-    def _inner(m):
-        title,text = m.groups()
-        if title.lower() not in _styles: return f"> {m.groups()[0]}: {m.groups()[1]}"
-        return '{% include '+title.lower()+".html content=\'`"+_to_html(text)+"`\' %}"
-    if cell['cell_type'] == 'markdown':
-        cell['source'] = _re_block_notes.sub(_inner, cell['source'])
-    return cell
-
 # TODO: Open a GitHub Issue in addition to printing warnings
 for original, new in warnings:
     print(f'{original} has been renamed to {new} to be complaint with Jekyll naming conventions.\n')
     
 ## apply monkey patches
 export2html._nb2htmlfname = _nb2htmlfname
-export2html.process_cell.append(add_embedded_links)
 
 export2html.notebook2html(fname='_notebooks/*.ipynb', dest='_posts/', template_file='/fastpages/fastpages.tpl')
 

--- a/_action_files/settings.ini
+++ b/_action_files/settings.ini
@@ -39,3 +39,4 @@ tst_flags = fastai2
 custom_sidebar = False
 cell_spacing = 1
 monospace_docstrings = False
+jekyll_styles = note,warning,tip,important,youtube,twitter


### PR DESCRIPTION
nbdev tool has been updated a week ago list below.

```python
def add_jekyll_notes(cell):
    "Convert block quotes to jekyll notes in `cell`"
    styles = Config().get('jekyll_styles', 'note,warning,tip,important').split(',')
    def _inner(m):
        title,text = m.groups()
        if title.lower() not in styles: return f"> {m.groups()[0]}: {m.groups()[1]}"
        return '{% include '+title.lower()+".html content=\'"+_to_html(text)+"\' %}"
    if cell['cell_type'] == 'markdown':
        cell['source'] = _re_block_notes.sub(_inner, cell['source'])
    return cell
```

styles are no longer static, but it tries to search for `jekyll_styles` key in `settings.ini`.
nbdev tool doesnt have such a key, so it defined a set of default values in the static code.

However, for fastpages, we could add `jekyll_styles` key in `settings.ini` with the values `note,warning,tip,important,youtube,twitter` like below

```
jekyll_styles = note,warning,tip,important,youtube,twitter
```

then we could completely remove `add_embedded_links` function from `_action_files/nb2post.py` source file. 