### PR TITLE
add support for tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,9 @@ use_math:
 # Set this to true to display the summary of your blog post under your title on the Home page.
 show_description: true
 
+# Set this to true to display tags on each post
+show_tags: true
+
 # Add your Google Analytics ID here if you have one and want to use it
 google_analytics:
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ layout: default
     {%- if page.description -%}
     <p class="page-description">{{ page.description | escape }}</p>
     {%- endif -%}
-    <p class="post-meta">
+    <p class="post-meta post-meta-title">
       {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
       <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
         {{ page.date | date: date_format }}
@@ -29,6 +29,16 @@ layout: default
       {%- endif -%}
     • {%- include reading_time.html -%}
     </p>
+
+    {% if page.categories.size > 0 and site.show_tags %}
+      <p class="category-tags"><i class="fas fa-tags category-tags-icon"></i></i> 
+      {% for category in  page.categories  %}
+        <a class="category-tags-link" href="{{site.baseurl}}/categories/#{{category|slugize}}">{{category}}</a>
+        {% unless forloop.last %}&nbsp;{% endunless %}
+      {% endfor %}
+      </p>
+    {% endif %}
+
     {% if page.layout == 'notebook' %}
       {% if page.badges or page.badges == nil %}
         <div class="pb-5 d-flex flex-wrap flex-justify-end">

--- a/_notebooks/2020-02-20-test.ipynb
+++ b/_notebooks/2020-02-20-test.ipynb
@@ -9,7 +9,8 @@
     "\n",
     "- toc: true \n",
     "- badges: true\n",
-    "- comments: true"
+    "- comments: true\n",
+    "- categories: [fastpages, jupyter]"
    ]
   },
   {

--- a/_posts/2020-01-14-test-markdown-post.md
+++ b/_posts/2020-01-14-test-markdown-post.md
@@ -1,6 +1,7 @@
 ---
 toc: true
 description: A minimal example of using markdown with fastpages.
+categories: [fastpages, markdown]
 ---
 # Example Markdown Post
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -324,3 +324,24 @@ h6:hover .anchor-link {
   color: #585858;
   font-size: 110%;
 }
+
+// category tags
+.category-tags {
+  margin-top: .25rem !important;
+  margin-bottom: .25rem !important;
+}
+
+.post-meta-title{
+  margin-top: .25em;
+  margin-bottom: .25em;
+}
+
+.category-tags-icon {
+  font-size: 75% !important;
+  padding-left: 0.375em;
+  opacity: 35%;
+}
+.category-tags-link {
+  color:rgb(187, 129, 129) !important;
+  font-size: 9px !important;
+}


### PR DESCRIPTION
You can now specify categories in front matter

```
---
toc: true
description: A minimal example of using markdown with fastpages.
categories: [fastpages, markdown]
---
```


You can show/hide these tags by setting this option in `_config.yml`

```
# Set this to true to display tags on each post
show_tags: true
```

# New Linkable Tags

If this value is `true` linkable tags will show up on your blog like this

![image](https://user-images.githubusercontent.com/1483922/75099425-5ba0fb00-5576-11ea-8283-6b0047fb1c92.png)

# New Tags Page

A new tags page has been added

![image](https://user-images.githubusercontent.com/1483922/75099414-4330e080-5576-11ea-8f50-b34318f2c00f.png)



