### PR TITLE
Added excludes for internal fastpages in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,12 @@ show_tags: true
 # Add your Google Analytics ID here if you have one and want to use it
 google_analytics:
 
+exclude:
+  - CONTRIBUTING.md
+  - settings.ini
+  - docker-compose.yml
+  - action.yml
+
 # Everything below here should be left alone. Modifications may break fastpages
 theme: minima
 plugins:


### PR DESCRIPTION
I noticed that by default some fastpages internals will get processed by jekyll, and show up on the website, i.e. https://respawn.io/settings.ini. 

That's a quick fix.