### PR TITLE
Bump nokogiri re: security alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.14.0)
     multipart-post (2.1.1)
-    nokogiri (1.10.7)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     octicons (9.4.0)
       nokogiri (>= 1.6.3.1)


### PR DESCRIPTION
That only changes a single dependency minor version. In general, we should probably install Dependabot to patch up CVEs quickly? → https://dependabot.com