### PR TITLE
Add README to _posts to ensure the directory always exists in git index

### DIFF
--- a/_posts/README.md
+++ b/_posts/README.md
@@ -1,0 +1,13 @@
+# Auto-convert markdown files To Posts
+
+[`fastpages`](https://github.com/fastai/fastpages) will automatically convert markdown files saved into this directory as blog posts!
+
+You must save your notebook with the naming convention `YYYY-MM-DD-*.md`.  Examples of valid filenames are:
+
+```shell
+2020-01-28-My-First-Post.md
+2012-09-12-how-to-write-a-blog.md
+```
+
+See [Writing Blog Posts With Jupyter](https://github.com/saketkc/fastpages#writing-blog-posts-with-markdown) for more details.
+


### PR DESCRIPTION
If you delete the default `2020-01-14-test-markdown-post.md` files under `_posts`, the directory also gets removed from the git index and as such any notebook pushed under `_notebooks` will not build
![Update nb · saketkc pertinent-stats ab20506](https://user-images.githubusercontent.com/682153/75313312-5dd2b600-5811-11ea-821d-cd0ff7d1657b.png)
