### PR TITLE
Change Image Cards on Home Page To Appear On Side of Post

### DIFF
--- a/_includes/post_list.html
+++ b/_includes/post_list.html
@@ -1,0 +1,9 @@
+<h3>
+    <a class="post-link" href="{{ post.url | relative_url }}">
+    {{ post.title | escape }}
+    </a>
+</h3>
+{%- if site.show_description and post.description  -%}
+<p class="post-meta-description">{{ post.description }}</p>
+{%- endif -%}
+<p class="post-meta">{{ post.date | date: date_format }}</p>

--- a/_includes/post_list_image_card.html
+++ b/_includes/post_list_image_card.html
@@ -1,0 +1,16 @@
+<div class="Box box-shadow-medium rounded-1 col-12">
+    {%- if post.image -%}
+    <div class="col-4 d-table-cell p-3 v-align-middle">
+        <img class="image-preview " src="{{ post.image | relative_url }}" />
+      </div>
+    {%- endif -%}
+    <div class="col-8 d-table-cell p-3">
+        <h3>
+          <a class="post-link" href="{{ post.url | relative_url }}">
+            {{ post.title | escape }}
+          </a>
+        </h3>
+        <p class="post-meta-description">{{ post.description }}</p>
+          <p class="post-meta">{{ post.date | date: date_format }}</p>
+      </div>
+  </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -24,30 +24,13 @@ layout: default
     <ul class="post-list">
       {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
       {%- for post in posts -%}
-        {%- if site.show_image  -%}
-          <div class="Box box-shadow-large p-3">
-        {%- endif -%}
-
-        {%- if site.show_image and post.image  -%}
-        <div class="Subhead flex-justify-center">
-          <img class="image-preview" src="{{ post.image | relative_url }}" />
-        </div>
-        {%- endif -%}
       <li>
-        <h3>
-          <a class="post-link" href="{{ post.url | relative_url }}">
-            {{ post.title | escape }}
-          </a>
-        </h3>
-        {%- if site.show_description and post.description  -%}
-        <p class="post-meta-description">{{ post.description }}</p>
+        {%- if site.show_image -%}
+            {%- include post_list_image_card.html -%}
+        {% else %}
+            {%- include post_list.html -%}
         {%- endif -%}
-          <p class="post-meta">{{ post.date | date: date_format }}</p>
       </li>
-    {%- if site.show_image  -%}
-    </div>
-    <br><br>
-    {%- endif -%}
       {%- endfor -%}
     </ul>
 


### PR DESCRIPTION
Per discussion in https://forums.fast.ai/t/fastpages-index-page-styling-improvements/64120

Note we are using [primer.css](https://primer.style/) with grid system, to achieve this styling, not creating our own CSS.

Posts no appear like this when `show_images: true`  in `/_config.yml`

![image](https://user-images.githubusercontent.com/1483922/75317810-bc9e2c80-581d-11ea-9850-4753a9450727.png)

The third case shown is when you turn this option on but fail to supply an image for the blog post.


cc: @jph00 

Again, **this is off by deafult**