### PR TITLE
Update settings.ini to fix local images when not using a root url

### DIFF
--- a/_action_files/settings.ini
+++ b/_action_files/settings.ini
@@ -32,7 +32,7 @@ console_scripts = nbdev_build_lib=nbdev.cli:nbdev_build_lib
 nbs_path = nbs
 doc_path = images/copied_from_nb
 doc_host = https://nbdev.fast.ai
-doc_baseurl = /images/copied_from_nb/
+doc_baseurl = {{site.baseurl}}/images/copied_from_nb/
 git_url = https://github.com/fastai/nbdev/tree/master/
 lib_path = nbdev
 tst_flags = fastai2


### PR DESCRIPTION
Per https://forums.fast.ai/t/fastpages-github-pages-blog-using-nbdev/62828/79

![image](https://user-images.githubusercontent.com/1483922/75415258-f59ed580-58df-11ea-9786-d038070e52db.png)

This injects liquid code into the URL generated by nbdev to correct the relative path.
