### PR TITLE
fix link to announcement

### DIFF
--- a/_notebooks/2020-02-21-introducing-fastpages.ipynb
+++ b/_notebooks/2020-02-21-introducing-fastpages.ipynb
@@ -12,7 +12,7 @@
     "- comments: true\n",
     "- author: Jeremy Howard & Hamel Husain\n",
     "- image: images/diagram.png\n",
-    "- categories: [jupyter, fastpages]"
+    "- categories: [fastpages, jupyter]"
    ]
   },
   {


### PR DESCRIPTION
apparently order of tags matters in creation of URL

cc: @jph00 attempt number 2