### PR TITLE
[Do Not Merge] Fastpages Blog Post: show observable example

### DIFF
--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -66,6 +66,7 @@ jobs:
         git checkout -B fastpages-automated-setup
         git rm CNAME action.yml
         git rm _notebooks/2020-02-21-introducing-fastpages.ipynb
+        git rm _notebooks/2020-02-19-Observable.ipynb
         git rm .github/workflows/chatops.yaml
         git rm .github/ISSUE_TEMPLATE/bug.md
         git rm .github/ISSUE_TEMPLATE/feature_request.md

--- a/_notebooks/2020-02-19-Observable.ipynb
+++ b/_notebooks/2020-02-19-Observable.ipynb
@@ -72,7 +72,7 @@
    "source": [
     "## Further Reading\n",
     "\n",
-    "- The [uwdata/visualization-curriculum](https://github.com/uwdata/visualization-curriculum) repo is a great place to learn more about creating visualizations with Observable and Altair."
+    "The [uwdata/visualization-curriculum](https://github.com/uwdata/visualization-curriculum) repo is a great place to learn more about creating visualizations with Observable and Altair."
    ]
   }
  ],

--- a/_notebooks/2020-02-19-Observable.ipynb
+++ b/_notebooks/2020-02-19-Observable.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Interactive Visualizations With Observable\n",
+    "> A demo of using snippets from Observable in fastpages\n",
+    "- comments: true\n",
+    "- author: Hamel Husain\n",
+    "- categories: [fastpages, jupyter]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This demonstrates another way to inject interactive charts into fastpages, [similar to what we demonstrated with Altair](http://localhost:4000/jupyter/2020/02/20/test.html#Interactive-Charts-With-Altair), using javascript visualization libraries.\n",
+    "\n",
+    "You can embed visualizations made with [Observable](https://observablehq.com/) by using the methodology is defined in this tutorial: [\"Observable for Jupyter Users\"](https://observablehq.com/@observablehq/visualize-a-data-frame-with-observable-in-jupyter).  \n",
+    "\n",
+    "**Warning: This page can take > 5 seconds to load**.  The more data you embed in your charts, the longer a page may take to load."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"observablehq-b9a930e6\"></div>\n",
+       "<script type=\"module\">\n",
+       "import {Runtime, Inspector} from \"https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js\";\n",
+       "import define from \"https://api.observablehq.com/d/eceaa744227c4fea.js?v=3\";\n",
+       "const inspect = Inspector.into(\"#observablehq-b9a930e6\");\n",
+       "(new Runtime).module(define, name => (\n",
+       "  name === \"vegaPetalsWidget\" ||\n",
+       "  name === 'viewof sepalLengthLimits' ||\n",
+       "  name === 'viewof sepalWidthLimits') && inspect());\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# show-collapse\n",
+    "from IPython.display import display, HTML\n",
+    "embed = \"\"\"<div id=\"observablehq-b9a930e6\"></div>\n",
+    "<script type=\"module\">\n",
+    "import {Runtime, Inspector} from \"https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js\";\n",
+    "import define from \"https://api.observablehq.com/d/eceaa744227c4fea.js?v=3\";\n",
+    "const inspect = Inspector.into(\"#observablehq-b9a930e6\");\n",
+    "(new Runtime).module(define, name => (\n",
+    "  name === \"vegaPetalsWidget\" ||\n",
+    "  name === 'viewof sepalLengthLimits' ||\n",
+    "  name === 'viewof sepalWidthLimits') && inspect());\n",
+    "</script>\n",
+    "\"\"\"\n",
+    "display(HTML(embed))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/_notebooks/2020-02-19-Observable.ipynb
+++ b/_notebooks/2020-02-19-Observable.ipynb
@@ -67,11 +67,13 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## Further Reading\n",
+    "\n",
+    "- The [uwdata/visualization-curriculum](https://github.com/uwdata/visualization-curriculum) repo is a great place to learn more about creating visualizations with Observable and Altair."
+   ]
   }
  ],
  "metadata": {

--- a/_notebooks/2020-02-19-Observable.ipynb
+++ b/_notebooks/2020-02-19-Observable.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "You can embed visualizations made with [Observable](https://observablehq.com/) by using the methodology is defined in this tutorial: [\"Observable for Jupyter Users\"](https://observablehq.com/@observablehq/visualize-a-data-frame-with-observable-in-jupyter).  \n",
     "\n",
-    "**Warning: This page can take > 5 seconds to load**.  The more data you embed in your charts, the longer a page may take to load."
+    "Warning: This page may several seconds to load.  The more data you embed in your charts, the longer a page may take to load."
    ]
   },
   {

--- a/_notebooks/2020-02-19-Observable.ipynb
+++ b/_notebooks/2020-02-19-Observable.ipynb
@@ -15,7 +15,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This demonstrates another way to inject interactive charts into fastpages, [similar to what we demonstrated with Altair](http://localhost:4000/jupyter/2020/02/20/test.html#Interactive-Charts-With-Altair), using javascript visualization libraries.\n",
+    "This demonstrates another way to inject interactive charts into fastpages, [similar to what we demonstrated with Altair](https://fastpages.fast.ai/jupyter/2020/02/20/test.html#Interactive-Charts-With-Altair), using javascript visualization libraries.\n",
     "\n",
     "You can embed visualizations made with [Observable](https://observablehq.com/) by using the methodology is defined in this tutorial: [\"Observable for Jupyter Users\"](https://observablehq.com/@observablehq/visualize-a-data-frame-with-observable-in-jupyter).  \n",
     "\n",
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -423,7 +423,7 @@ table {
 }
 
 .range-track {
-  positoin: relative;
+  position: relative;
 }
 .range-track-zone{
   position: absolute;

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -421,3 +421,11 @@ table {
 ::-webkit-scrollbar-corner {
   background-color: transparent;
 }
+
+.range-track {
+  positoin: relative;
+}
+.range-track-zone{
+  position: absolute;
+  top: -15px;
+}


### PR DESCRIPTION
Add a fastpages blog post example to fastpages that showcases open source javascript libraries and with references to Observable notebooks 

cc: @thomasballinger @jph00 

P.S. I backdated this blog post so that it appears under the "announcing fastpages" one. 