### PR TITLE
Remove jupyter from dev environment to simplify things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ stop: .FORCE
 remove: .FORCE
 	docker-compose stop  || true; docker-compose rm || true;
 
-# get shell inside the notebook service (Must already be running)
+# get shell inside the notebook converter service (Must already be running)
 bash-nb: .FORCE
 	docker-compose exec watcher /bin/bash
 

--- a/_fastpages_docs/DEVELOPMENT.md
+++ b/_fastpages_docs/DEVELOPMENT.md
@@ -7,7 +7,7 @@
     - [Rebuild all the containers](#rebuild-all-the-containers)
     - [Removing all the containers](#removing-all-the-containers)
     - [Attaching a shell to a container](#attaching-a-shell-to-a-container)
-
+  - [Running a Jupyter Server](#running-a-jupyter-server)
 
 You can run your fastpages blog on your local machine, and view any changes you make to your posts, including Jupyter Notebooks and Word documents, live.
 The live preview requires that you have Docker installed on your machine. [Follow the instructions on this page if you need to install Docker.](https://www.docker.com/products/docker-desktop)
@@ -33,8 +33,7 @@ When you run this command for the first time, it'll build the required Docker im
 
 This command will build all the necessary containers and run the following services:
 1. A service that monitors any changes in `./_notebooks/*.ipynb/` and `./_word/*.docx;*.doc` and rebuild the blog on change.
-2. A Jupyter Notebook server — use this to write and edit your posts.  **You must see your terminal logs to find the link**, which will start with `https://127.0.0.1:8888`
-3. A Jekyll server on https://127.0.0.1:4000 — use this to preview your blog.
+2. A Jekyll server on https://127.0.0.1:4000 — use this to preview your blog.
 
 The services will output to your terminal. If you close the terminal or hit `Ctrl-C`, the services will stop.
 If you want to run the services in the background:
@@ -53,17 +52,6 @@ _Note that the blog won't autoreload on change, you'll have to refresh your brow
 
 **If containers won't start**: try `make build` first, this would rebuild all the containers from scratch, This might fix the majority of update problems.
 
-**To get the Jupyter Notebook Token**: look for the Jupyter Notebook link in the output log of `make server` command, it'll post the link with the token param in it. If you're running containers in background, you can get the token by running the following command: 
-
-```bash
-# assuming you're running containers in background with docker-compose up -d
-# attach to bash in jupyter container
-make bash-nb
-
-# get notebook list & token
-jupyter notebook list
-```
-
 ## Converting the pages locally
 
 If you just want to convert your notebooks and word documents to `.md` posts in `_posts`, this command will do it for you:
@@ -76,7 +64,7 @@ You can launch just the jekyll server with `make server`.
 
 ## Visual Studio Code integration
 
-If you're using VSCode with the Docker extension, you can run three containers from the sidebar: `fastpages_jupyter_1`,`fastpages_watcher_1`, and `fastpages_jekyll_1`.
+If you're using VSCode with the Docker extension, you can run these containers from the sidebar: `fastpages_watcher_1` and `fastpages_jekyll_1`.
 The containers will only show up in the list after you run or build them for the first time. So if they're not in the list — try `make build` in the console.
 
 ## Advanced usage
@@ -105,11 +93,16 @@ You can attach a terminal to a running service:
 # attach to a bash shell in the jekyll service
 make bash-jekyll
 
-# attach to a bash shell in the jupyter / watcher service.
-# they're essentially running the same software inside.
+# attach to a bash shell in the watcher service.
 make bash-nb
 ```
 
 _Note: you can use `docker-compose run` instead of `make bash-nb` or `make bash-jekyll` to start a service and then attach to it.
 Or you can run all your services in the background, `make server-detached`, and then use `make bash-nb` or `make bash-jekyll` as in the examples above._
 
+## Running A Jupyter Server
+
+The fastpages development enviornment does not provide a Jupyter server for you.  This is intentional so that you are free to run Jupyter Notebooks or Jupyter Lab in a manner that is familiar to you, and manage dependencies (requirements.txt, conda, etc) in the way you wish.  Some tips that may make your life easier:
+
+- Provide instructions in your README and your blog posts on how to install the dependencies required to run your notebooks.  This will make it eaiser for your audience to reproduce your notebooks.
+- Do not edit the Dockerfile in `/_action_files`, as that may interfere with the blogging environment.  Furthermore, any changes you make to these files may get lost in future upgrades, if [upgrading automatically](UGPRADE.md).  Instead, if you wish to manage your Jupyter server with Docker, we recommend that you maintain a seperate Dockerfile at the root of your repository.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,12 +25,6 @@ services:
     <<: *fastpages
     command: watchmedo shell-command --command /fastpages/action_entrypoint.sh --pattern *.ipynb --recursive --drop
 
-  jupyter:
-    <<: *fastpages
-    ports:
-      - "8888:8888"
-    command: jupyter notebook ./_notebooks --no-browser --allow-root --ip=0.0.0.0 --port=8888
-
   jekyll:
     working_dir: /data
     image: jekyll/jekyll


### PR DESCRIPTION
Per https://forums.fast.ai/t/modulenotfounderror/64163/11, I think the inclusion of Jupyter Server in the development environment could be confusing for people.

## Summary of Changes

- Removed Jupyter Server (not the watcher) from the development environment
- Edited instructions in DEVELOPMENT.md that users start/manage their own Jupyter server on their own, in the manner they are most comfortable with.  

## Reason for this change

- Encourages people to use package management etc they are comfortable with which might be easier for them
- Simplifies the development environment considerably (no tokens, no jupyter server, etc)
- Encourages folks to maintain a development enviornment with all their dependencies (fastai, pytorch, tensorflow, etc. whatever) that is decoupled from the converter and Jekyll server, which is much safer, and a better way to ensure that the development environment mirrors what happens in GitHub Actions. 
- Makes this project easier to maintain as we can focus on fastpages, not managing a gloabl "data science" dependency manager for the software you want to run in your notebooks

cc: @xnutsive 