### PR TITLE
Update Jekyll Docker Image Automatically when Gemfile changes

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,16 +1,16 @@
 name: Build-Docker
 on:
     push:
-        # paths:
-        #     - Gemfile*
-        # branches:
-        #     - master
-    # pull_request:
-    #     # paths:
-    #     #     - Gemfile*
+        paths:
+            - Gemfile*
+        branches:
+            - master
+    pull_request:
+        paths:
+            - Gemfile*
 
 jobs:
-    docker:
+    jekyll-fastpages:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master
@@ -27,6 +27,3 @@ jobs:
               env:
                 USERNAME: ${{ secrets.DOCKER_USERNAME }}
                 PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
-
-

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,30 @@
+name: Build-Docker
+on:
+    push:
+        paths:
+            - Gemfile*
+    pull_request:
+        # paths:
+        #     - Gemfile*
+
+jobs:
+    docker:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            
+            - name: build container
+              run: |
+                docker build -t hamelsmu/fastpages-jekyll -f _action_files/fastpages-jekyll.Dockerfile .
+
+            - name: push container
+              if: github.event == 'push'
+              run: |
+                  echo ${PASSWORD} | docker login -u $USERNAME --password-stdin
+                  docker push hamelsmu/fastpages-jekyll
+                env:
+                  USERNAME: ${{ secrets.DOCKER_USERNAME }}
+                  PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+
+

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,13 +1,13 @@
 name: Build-Docker
 on:
     push:
-        paths:
-            - Gemfile*
-        # branches:
-        #     - master
-    pull_request:
         # paths:
         #     - Gemfile*
+        # branches:
+        #     - master
+    # pull_request:
+    #     # paths:
+    #     #     - Gemfile*
 
 jobs:
     docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,6 +3,8 @@ on:
     push:
         paths:
             - Gemfile*
+        # branches:
+        #     - master
     pull_request:
         # paths:
         #     - Gemfile*
@@ -20,11 +22,11 @@ jobs:
             - name: push container
               if: github.event == 'push'
               run: |
-                  echo ${PASSWORD} | docker login -u $USERNAME --password-stdin
-                  docker push hamelsmu/fastpages-jekyll
-                env:
-                  USERNAME: ${{ secrets.DOCKER_USERNAME }}
-                  PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+                echo ${PASSWORD} | docker login -u $USERNAME --password-stdin
+                docker push hamelsmu/fastpages-jekyll
+              env:
+                USERNAME: ${{ secrets.DOCKER_USERNAME }}
+                PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
 
 

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -67,6 +67,7 @@ jobs:
         git rm CNAME action.yml
         git rm _notebooks/2020-02-21-introducing-fastpages.ipynb
         git rm .github/workflows/chatops.yaml
+        git rm .github/workflows/docker.yaml
         git rm .github/ISSUE_TEMPLATE/bug.md
         git rm .github/ISSUE_TEMPLATE/feature_request.md
         git add _config.yml README.md _fastpages_docs/ _action_files/settings.ini

--- a/_action_files/fastpages-jekyll.Dockerfile
+++ b/_action_files/fastpages-jekyll.Dockerfile
@@ -1,0 +1,8 @@
+# Defines https://hub.docker.com/repository/docker/hamelsmu/fastpages-jekyll
+FROM jekyll/jekyll:4.0.0
+
+COPY . .
+
+# Pre-load all gems into the environment
+RUN gem install bundler 
+RUN jekyll build


### PR DESCRIPTION
This PR automatically refreshes the Docker container and pushes it to Dockerhub in the event the Gemfile or Gemfile.lock file(s) change.  The Action will build the Docker container on a pull request as a test to see if this file has changed, but will not push to DockerHub (because it doesn't have access to secrets).  However, when a push is made to master that involves a Gemfile, the Docker image on DockerHub will be updated.

Tagging @jph00 for informational purposes for visibility on how this works.