### PR TITLE
CRON Task in Actions That Builds Nbdev

### DIFF
--- a/.github/workflows/docker-nbdev.yaml
+++ b/.github/workflows/docker-nbdev.yaml
@@ -1,7 +1,7 @@
 name: Build-Nbdev-Docker
 on:
     schedule:
-      - cron:  '0 12 * * *'
+      - cron:  '0 */12 * * *'
 
 jobs:
     nbdev-docker-fastpages:

--- a/.github/workflows/docker-nbdev.yaml
+++ b/.github/workflows/docker-nbdev.yaml
@@ -1,0 +1,23 @@
+name: Build-Nbdev-Docker
+on:
+    schedule:
+      - cron:  '0 12 * * *'
+
+jobs:
+    nbdev-docker-fastpages:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            
+            - name: build container
+              run: |
+                docker build -t hamelsmu/fastpages-nbdev -f _action_files/fastpages-nbdev.Dockerfile ./_action_files
+
+            - name: push container
+              if: github.event == 'push'
+              run: |
+                echo ${PASSWORD} | docker login -u $USERNAME --password-stdin
+                docker push hamelsmu/fastpages-nbdev
+              env:
+                USERNAME: ${{ secrets.DOCKER_USERNAME }}
+                PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker-nbdev.yaml
+++ b/.github/workflows/docker-nbdev.yaml
@@ -14,7 +14,6 @@ jobs:
                 docker build -t hamelsmu/fastpages-nbdev -f _action_files/fastpages-nbdev.Dockerfile ./_action_files
 
             - name: push container
-              if: github.event == 'push'
               run: |
                 echo ${PASSWORD} | docker login -u $USERNAME --password-stdin
                 docker push hamelsmu/fastpages-nbdev

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -68,6 +68,7 @@ jobs:
         git rm _notebooks/2020-02-21-introducing-fastpages.ipynb
         git rm .github/workflows/chatops.yaml
         git rm .github/workflows/docker.yaml
+        git rm .github/workflows/docker-nbdev.yaml
         git rm .github/ISSUE_TEMPLATE/bug.md
         git rm .github/ISSUE_TEMPLATE/feature_request.md
         git add _config.yml README.md _fastpages_docs/ _action_files/settings.ini

--- a/_action_files/Dockerfile
+++ b/_action_files/Dockerfile
@@ -1,12 +1,3 @@
-# FROM python:3-slim-stretch
-
-# RUN pip install --upgrade pip
-# RUN apt-get update; apt-get -y install wget git jq
-# RUN wget https://github.com/jgm/pandoc/releases/download/2.9.1.1/pandoc-2.9.1.1-1-amd64.deb
-# RUN dpkg -i pandoc-2.9.1.1-1-amd64.deb
-# RUN pip install jupyter watchdog[watchmedo] jupyter_client ipykernel jupyter
-# RUN python3 -m ipykernel install --user
-# RUN pip install nbdev
 FROM hamelsmu/fastpages-nbdev
 
 WORKDIR /fastpages

--- a/_action_files/Dockerfile
+++ b/_action_files/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3-slim-stretch
+# FROM python:3-slim-stretch
 
-RUN pip install --upgrade pip
-RUN apt-get update; apt-get -y install wget git jq
-RUN wget https://github.com/jgm/pandoc/releases/download/2.9.1.1/pandoc-2.9.1.1-1-amd64.deb
-RUN dpkg -i pandoc-2.9.1.1-1-amd64.deb
-RUN pip install jupyter watchdog[watchmedo] jupyter_client ipykernel jupyter
-RUN python3 -m ipykernel install --user
-RUN pip install nbdev
+# RUN pip install --upgrade pip
+# RUN apt-get update; apt-get -y install wget git jq
+# RUN wget https://github.com/jgm/pandoc/releases/download/2.9.1.1/pandoc-2.9.1.1-1-amd64.deb
+# RUN dpkg -i pandoc-2.9.1.1-1-amd64.deb
+# RUN pip install jupyter watchdog[watchmedo] jupyter_client ipykernel jupyter
+# RUN python3 -m ipykernel install --user
+# RUN pip install nbdev
+FROM hamelsmu/fastpages-nbdev
 
 WORKDIR /fastpages
 COPY . .

--- a/_action_files/fastpages-nbdev.Dockerfile
+++ b/_action_files/fastpages-nbdev.Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3-slim-stretch
+
+RUN pip install --upgrade pip
+RUN apt-get update; apt-get -y install wget git jq
+RUN wget https://github.com/jgm/pandoc/releases/download/2.9.1.1/pandoc-2.9.1.1-1-amd64.deb
+RUN dpkg -i pandoc-2.9.1.1-1-amd64.deb
+RUN pip install jupyter watchdog[watchmedo] jupyter_client ipykernel jupyter
+RUN python3 -m ipykernel install --user
+RUN pip install nbdev


### PR DESCRIPTION
We are able to bring the entire build time in Actions end to end very close to a minute by also prebuilding nbdev.  A CRON task build the nbdev cotnainer twice daily.  cc: @jph00 for visibility on how it works

# Before Today ~ 3Minutes

![image](https://user-images.githubusercontent.com/1483922/76042248-13d08b00-5f09-11ea-86a2-8e0099528d76.png)


# Before This PR ~ 2 Minutes

![image](https://user-images.githubusercontent.com/1483922/76042068-9c9af700-5f08-11ea-8166-3a3c71376c82.png)


# With This PR ~ 1 Minute


![image](https://user-images.githubusercontent.com/1483922/76042057-9573e900-5f08-11ea-9e09-b0e82c4ef631.png)

