### PR TITLE
Enable Pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :jekyll_plugins do
   gem 'jekyll-seo-tag'
   gem 'jekyll-toc'
   gem 'jekyll-gist'
+  gem 'jekyll-paginate'
 end
 
 gem "kramdown-math-katex"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
     jekyll-octicons (9.5.0)
       jekyll (>= 3.6, < 5.0)
       octicons (= 9.5.0)
+    jekyll-paginate (1.1.0)
     jekyll-relative-links (0.6.1)
       jekyll (>= 3.3, < 5.0)
     jekyll-remote-theme (0.4.2)
@@ -115,6 +116,7 @@ DEPENDENCIES
   jekyll-feed (~> 0.12)
   jekyll-gist
   jekyll-octicons
+  jekyll-paginate
   jekyll-relative-links
   jekyll-remote-theme
   jekyll-seo-tag

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,13 @@ server-detached: .FORCE
 # build or rebuild the services WITHOUT cache
 build: .FORCE
 	docker-compose stop || true; docker-compose rm || true;
+	docker build -t hamelsmu/fastpages-jekyll -f _action_files/fastpages-jekyll.Dockerfile .
 	docker-compose build --force-rm --no-cache
 
 # rebuild the services WITH cache
 quick-build: .FORCE
 	docker-compose stop || true;
+	docker build -t hamelsmu/fastpages-jekyll -f _action_files/fastpages-jekyll.Dockerfile .
 	docker-compose build 
 
 # convert word & nb without Jekyll services

--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ fastpages comes with built in keyword search powered by [lunr.js](https://lunrjs
 
 ![tags](_fastpages_docs/_post_tags.png)
 
+- `pagination`: This is the maximum number of posts to show on each page of your home page.  Any posts exceeding this amount will be paginated onto another page.  This is set to `15` by default.  When this is triggered, you will see pagination at the bottom of your home page appear like this:
+
+![paginate](_fastpages_docs/_paginate.png)
 
 ## Writing Blog Posts With Jupyter
 

--- a/README.md
+++ b/README.md
@@ -218,11 +218,27 @@ fastpages comes with built in keyword search powered by [lunr.js](https://lunrjs
 
 - `show_tags`: You can toggle the display of tags on your blog posts on or off by setting this value to `false`.  This is set to `true` by default, which which renders the following links for tags on your blog posts like this:
 
-![tags](_fastpages_docs/_post_tags.png)
+  ![tags](_fastpages_docs/_post_tags.png)
 
 - `pagination`: This is the maximum number of posts to show on each page of your home page.  Any posts exceeding this amount will be paginated onto another page.  This is set to `15` by default.  When this is triggered, you will see pagination at the bottom of your home page appear like this:
 
-![paginate](_fastpages_docs/_paginate.png)
+  ![paginate](_fastpages_docs/_paginate.png)
+
+  Note: if you are using an older version of fastpages, **you cannot use the automated upgrade process** to get pagination.  Instead you must follow these steps:
+
+    1. Rename your index.md file to index.html 
+         > mv index.md index.html
+    2. Replace the `Gemfile` and `Gemfile.lock` in the root of your repo with the files in this repo.
+    3. Edit your `_config.yml` as follows (look at [_config.yml](_config.yml) for a example):
+        ```yaml
+        gems:
+        - jekyll-paginate
+
+        paginate: 10
+        paginate_path: /page:num/
+        ```
+
+    _Alternatively, you can copy all of your posts over to a newly created  repository created from the fastpages template._
 
 ## Writing Blog Posts With Jupyter
 

--- a/_config.yml
+++ b/_config.yml
@@ -78,6 +78,11 @@ plugins:
   - jekyll-relative-links
   - jekyll-seo-tag
   - jekyll-remote-theme
+  - jekyll-paginate
+
+# See https://jekyllrb.com/docs/pagination/
+paginate: 15
+paginate_path: /page:num/
 
 remote_theme: jekyll/minima
 

--- a/_config.yml
+++ b/_config.yml
@@ -81,6 +81,7 @@ plugins:
   - jekyll-paginate
 
 # See https://jekyllrb.com/docs/pagination/
+# For pagination to work, you cannot have index.md at the root of your repo, instead you must rename this file to index.html
 paginate: 15
 paginate_path: /page:num/
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,7 +7,7 @@ layout: default
     <h1 class="page-heading">{{ page.title }}</h1>
   {%- endif -%}
 
-  {{ content }}
+  {{ content | markdownify }}
 
 
   {% if site.paginate %}
@@ -42,7 +42,7 @@ layout: default
       {%- endfor -%}
     </ul>
 
-    {% if site.paginate %}
+    {% if site.paginate and site.posts.size > site.paginate %}
       <div class="pager">
         <ul class="pagination">
         {%- if paginator.previous_page %}

--- a/index.html
+++ b/index.html
@@ -9,6 +9,6 @@ This site is built with [fastpages](https://github.com/fastai/fastpages), An eas
 
 [fastpages](https://github.com/fastai/fastpages) automates the process of creating blog posts via GitHub Actions, so you don't have to fuss with conversion scripts.  A full list of features can be found on [GitHub](https://github.com/fastai/fastpages).  
 
-You can edit the `index.md` file to change this content.
+You can edit the `index.html` file to change this content.
 
 # Posts

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ search_exclude: true
 
 This site is built with [fastpages](https://github.com/fastai/fastpages), An easy to use blogging platform with extra features for Jupyter Notebooks.
 
-![](images/diagram.png "https://github.com/fastai/fastpages")
+![](/images/diagram.png "https://github.com/fastai/fastpages")
 
 [fastpages](https://github.com/fastai/fastpages) automates the process of creating blog posts via GitHub Actions, so you don't have to fuss with conversion scripts.  A full list of features can be found on [GitHub](https://github.com/fastai/fastpages).  
 


### PR DESCRIPTION
Enabled new parameter in `config.yml`


`pagination`: This is the maximum number of posts to show on each page of your home page.  Any posts exceeding this amount will be paginated onto another page.  This is set to `15` by default.  When this is triggered, you will see pagination at the bottom of your home page appear like this:

![image](https://user-images.githubusercontent.com/1483922/76346532-6f609700-62c2-11ea-87c4-b009a3435c2e.png)

index.md has been changed to index.html, and this is a breaking change.  So you cannot upgrade manually.  I have included instructions in the README on how to get this functionality.  

This closes: https://github.com/fastai/fastpages/issues/48

cc: @zonca  ( you may want to edit your blog post, now as this is turned on by default.  BTW,I figured out how to allow you to write markdown in index.html without any crazy hacks )

