### PR TITLE
Suggest `requirements.txt` for binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This option works for **notebooks only**
       - badges: true
       - hide_binder_badge: true
       ```
-  - **Note about Binder**: Binder allows you to customize the dependencies and other aspects of the Jupyter Notebook environment for your readers. You can learn more [on the official Binder docs](https://mybinder.readthedocs.io/en/latest/introduction.html).
+  - **Note about Binder**: Binder allows you to customize the dependencies and other aspects of the Jupyter Notebook environment for your readers. The easiest way is to add a `requirements.txt` file with common packages you use for all your notebooks at the root of your repository, you can learn more [on the official Binder docs](https://mybinder.readthedocs.io/en/latest/introduction.html).
 
 ### Categories
   - You can have a comma seperated list inside square brackets of categories for a blog post, which will make the post visible on the tags page of your blog's site.  For example:


### PR DESCRIPTION
The default binder environment doesn't even have `numpy`, so recommend a quick solution in the docs.
Related to #211 and #216