### PR TITLE
Bump version of nbdev in  fastpages-nbdev.Dockerfile

### DIFF
--- a/_action_files/fastpages-nbdev.Dockerfile
+++ b/_action_files/fastpages-nbdev.Dockerfile
@@ -6,4 +6,4 @@ RUN wget https://github.com/jgm/pandoc/releases/download/2.9.1.1/pandoc-2.9.1.1-
 RUN dpkg -i pandoc-2.9.1.1-1-amd64.deb
 RUN pip install jupyter watchdog[watchmedo] jupyter_client ipykernel jupyter
 RUN python3 -m ipykernel install --user
-RUN pip install nbdev==0.2.13
+RUN pip install nbdev==0.2.15


### PR DESCRIPTION
Related to https://github.com/fastai/nbdev/issues/105 and https://github.com/fastai/nbdev/issues/104