### PR TITLE
fix code blocks in headings

### DIFF
--- a/_sass/minima/fastpages-styles.scss
+++ b/_sass/minima/fastpages-styles.scss
@@ -53,6 +53,9 @@ p {
 h1, h2, h3, h4 {
     font-weight: normal !important;
     margin-bottom:0.5rem !important;  
+    code {
+      font-size: 100%;
+    }
 }
 
 pre {


### PR DESCRIPTION
Now, code blocks in headings match the font size of the heading.

![image](https://user-images.githubusercontent.com/1483922/77243559-8fe4f700-6bc8-11ea-85bd-44b53d26da50.png)

Per: https://forums.fast.ai/t/fastpages-github-pages-blog-using-nbdev/62828/167

This closes: https://github.com/fastai/fastpages/issues/223