### PR TITLE
Fix invalid image link

### DIFF
--- a/_fastpages_docs/_setup_pr_template.md
+++ b/_fastpages_docs/_setup_pr_template.md
@@ -8,7 +8,7 @@ Hello :wave: @{_username_}!  Thank you for using fastpages!
 
 3. Navigate to <a href="https://github.com/{_username_}/{_repo_name_}/settings/keys" target="_blank">this link</a> and click the `Add deploy key` button.  Paste your **Public Key** from step 1 into the `Key` box.  In the `Title`, name the key anything you want, for example `fastpages-key`.  Finally, **make sure you click the checkbox next to `Allow write access`** (pictured below), and click `Add key` to save the key.
 
-![](_fastpages_docs/_checkbox.png)
+![](https://raw.githubusercontent.com/{_username_}/{_repo_name_}/master/_fastpages_docs/_checkbox.png)
 
 
 ### What to Expect After Merging This PR

--- a/_fastpages_docs/_setup_pr_template.md
+++ b/_fastpages_docs/_setup_pr_template.md
@@ -8,7 +8,7 @@ Hello :wave: @{_username_}!  Thank you for using fastpages!
 
 3. Navigate to <a href="https://github.com/{_username_}/{_repo_name_}/settings/keys" target="_blank">this link</a> and click the `Add deploy key` button.  Paste your **Public Key** from step 1 into the `Key` box.  In the `Title`, name the key anything you want, for example `fastpages-key`.  Finally, **make sure you click the checkbox next to `Allow write access`** (pictured below), and click `Add key` to save the key.
 
-![](https://github.com/fastai/fastpages/blob/master/_fastpages_docs/_checkbox.png)
+![](https://raw.githubusercontent.com/fastai/fastpages/master/_fastpages_docs/_checkbox.png)
 
 
 ### What to Expect After Merging This PR

--- a/_fastpages_docs/_setup_pr_template.md
+++ b/_fastpages_docs/_setup_pr_template.md
@@ -8,7 +8,7 @@ Hello :wave: @{_username_}!  Thank you for using fastpages!
 
 3. Navigate to <a href="https://github.com/{_username_}/{_repo_name_}/settings/keys" target="_blank">this link</a> and click the `Add deploy key` button.  Paste your **Public Key** from step 1 into the `Key` box.  In the `Title`, name the key anything you want, for example `fastpages-key`.  Finally, **make sure you click the checkbox next to `Allow write access`** (pictured below), and click `Add key` to save the key.
 
-![](https://raw.githubusercontent.com/{_username_}/{_repo_name_}/master/_fastpages_docs/_checkbox.png)
+![](https://github.com/fastai/fastpages/blob/master/_fastpages_docs/_checkbox.png)
 
 
 ### What to Expect After Merging This PR


### PR DESCRIPTION
> 3. Navigate to this link and click the Add deploy key button. Paste your Public Key from step 1 into the Key box. In the Title, name the key anything you want, for example fastpages-key. Finally, make sure you click the checkbox next to Allow write access (pictured below), and click Add key to save the key.

PR for "initial setup" says `(pictured below)`, but the picture seems not to be rendered because the link is invalid. In pull request, a relative link to files in the repository should not work fine.

<img width="1192" alt="スクリーンショット 2020-03-29 20 25 47" src="https://user-images.githubusercontent.com/1453749/77848043-b7594680-71fc-11ea-8229-9342b92fc247.png">
