### PR TITLE
Add language about need for double quotes for titles

### DIFF
--- a/_notebooks/2020-02-20-test.ipynb
+++ b/_notebooks/2020-02-20-test.ipynb
@@ -35,8 +35,8 @@
     "The first cell in your Jupyter Notebook or markdown blog post contains front matter. Front matter is metadata that can turn on/off options in your Notebook. It is formatted like this:\n",
     "\n",
     "```\n",
-    "# Title\n",
-    "> Awesome summary\n",
+    "# \"My Title\"\n",
+    "> \"Awesome summary\"\n",
     "\n",
     "- toc: true- branch: master- badges: true\n",
     "- comments: true\n",
@@ -48,7 +48,7 @@
     "- Setting `badges: true` will automatically include GitHub and Google Colab links to your notebook.\n",
     "- Setting `comments: true` will enable commenting on your blog post, powered by [utterances](https://github.com/utterance/utterances).\n",
     "\n",
-    "More details and options for front matter can be viewed on the [front matter section](https://github.com/fastai/fastpages#front-matter-related-options) of the README."
+    "The title and description need to be enclosed in double quotes only if they include special characters such as a colon. More details and options for front matter can be viewed on the [front matter section](https://github.com/fastai/fastpages#front-matter-related-options) of the README."
    ]
   },
   {
@@ -763,7 +763,36 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.3"
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As referenced in [this online discussion](https://forums.fast.ai/t/fastpages-github-pages-blog-using-nbdev/62828/209) with notebook posts it is important to enclose the title and description in double quotes especially when special characters such as a colon are used.  Failure to do so may result in the post not being displayed. 

The need for double quotes IS explained in the front-matter section of the [README.md](https://github.com/fastai/fastpages/blob/master/README.md#customizing-blog-posts-with-front-matter).  

However, some users may be guided instead by the [Fastpages Notebook Blog Post](https://fastpages.fast.ai/jupyter/2020/02/20/test.html) which is described as "A tutorial of fastpages for Jupyter notebooks" which is created by the notebook [2020-02-20-test.ipynb](https://github.com/fastai/fastpages/blob/master/_notebooks/2020-02-20-test.ipynb)   This discusses the front-matter requirements but does NOT illustrate or highlight the need for the double-quotes.

To fix this problem,  this PR simply suggests replacing the markdown text

```
# My Title
> Awesome summary
```
with
```
# "My Title"
> "Awesome summary"
```
and adding the following first sentence to the description in the same cell:
>The title and description need to be enclosed in double-quotes only if they include special characters such as a colon.* More details and options for front matter can be viewed on the [front matter section](https://github.com/fastai/fastpages#front-matter-related-options) of the README.


