### PR TITLE
fix for Twitter card preview of main blog page

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="twitter:card" content="summary" />
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
   {%- feed_meta -%}

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: home
 search_exclude: true
+image: images/logo.png
 ---
 
 This site is built with [fastpages](https://github.com/fastai/fastpages), An easy to use blogging platform with extra features for Jupyter Notebooks.


### PR DESCRIPTION
Two simple one-line changes to enable Twitter card/preview of main blog page.  
As per Forums thread: https://forums.fast.ai/t/fastpages-no-twitter-card-for-main-page/75209

Demo URL: https://drscotthawley.github.io/devblog4/.  Try entering that URL into [Twitter Card Validator](https://cards-dev.twitter.com/validator) vs. entering https://fastpages.fast.ai/