### PR TITLE
Update fastpages-styles.scss

### DIFF
--- a/_sass/minima/fastpages-styles.scss
+++ b/_sass/minima/fastpages-styles.scss
@@ -196,21 +196,13 @@ h6:hover .anchor-link {
   font-weight:bold;
 }
 
-// Handle Overflow With Table Output
-
 table {
   display: block !important;
-  overflow-x: auto;
   white-space: nowrap;
   font-size: 75%;
   border:none;
   th{
     text-align: center! important;
-  }
-  td{
-    text-overflow:ellipsis;
-    overflow:hidden;
-    max-width: 15em;
   }
 }
 


### PR DESCRIPTION
remove clipping on table cells, as discussed here:
https://forums.fast.ai/t/solved-markdown-tables-truncating-colums/76504/2