### PR TITLE
Update fastpages-styles.scss

### DIFF
--- a/_sass/minima/fastpages-styles.scss
+++ b/_sass/minima/fastpages-styles.scss
@@ -198,7 +198,8 @@ h6:hover .anchor-link {
 
 table {
   display: block !important;
-  white-space: nowrap;
+  white-space: normal;
+  max-width: 100%;
   font-size: 75%;
   border:none;
   th{


### PR DESCRIPTION
fix: wrong version of table style update was merged

@hamelsmu fastai#388 still had the orig proposal which neither of us liked, it needs the nowrap removed and max-width: 100% or tables will still overflow from the parent area.

This PR is what you were looking at on my blog yesterday.