### PR TITLE
Fix for CWE-1022  CWE-200

### DIFF
--- a/_includes/image.html
+++ b/_includes/image.html
@@ -1,5 +1,5 @@
 <figure>
-  {% if {{include.url}} %}<a class="no_icon" target="_blank" href="{{include.url}}">{% endif %}
+  {% if {{include.url}} %}<a class="no_icon" target="_blank" href="{{include.url}}" rel="noopener noreferrer">{% endif %}
     <img class="docimage" src="{{include.file}}" alt="{{include.alt}}" {% if {{include.max-width}} %}style="max-width: {{include.max-width}}px"{% endif %} />
     {% if {{include.url}} %}</a>{% endif %}
     {% if {{include.caption}} %}


### PR DESCRIPTION
`HTML links that open in a new tab or window allow the target page to access the DOM of the origin page using window.opener unless link type noopener or noreferrer is specified. This is a potential security risk.`

In the following example, a JSX element is created that corresponds to an HTML link opening the URL http://example.com in a new tab. Since it does not specify a link type, that page will be able to access the DOM of the origin page.

`var link = <a href="http://example.com" target="_blank">Example</a>;`

To fix this vulnerability, add a rel attribute:

`var link = <a href="http://example.com" target="_blank" rel="noopener noreferrer">Example</a>;`

further details available at
1. [CWE-1022](https://cwe.mitre.org/data/definitions/1022.html)
2. [CWE-200](https://cwe.mitre.org/data/definitions/200.html)