### PR TITLE
Limit size of  xml feed by setting smarter default options

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -115,3 +115,8 @@ kramdown:
   auto_ids: true
   hard_wrap: false
   syntax_highlighter: rouge
+
+# to limit size of xml as it can grow quite large.
+feed:
+  posts_limit: 5 #default posts_limit: 10
+  excerpt_only: true


### PR DESCRIPTION
This closes #446