### PR TITLE
Update links to point to new docs pages and sections

### DIFF
--- a/_notebooks/2020-09-01-fastcore.ipynb
+++ b/_notebooks/2020-09-01-fastcore.ipynb
@@ -357,7 +357,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ouch! That was painful.  Look at all the repeated variable names.  Do I really have to repeat myself like this when defining a class?  Not Anymore!  Checkout [store_attr](https://fastcore.fast.ai/utils.html#store_attr):"
+    "Ouch! That was painful.  Look at all the repeated variable names.  Do I really have to repeat myself like this when defining a class?  Not Anymore!  Checkout [store_attr](https://fastcore.fast.ai/basics.html#store_attr):"
    ]
   },
   {
@@ -400,7 +400,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are many more ways of customizing and using `store_attr` than I highlighted here.  Check out [the docs](https://fastcore.fast.ai/utils.html#store_attr) for more detail.\n",
+    "There are many more ways of customizing and using `store_attr` than I highlighted here.  Check out [the docs](https://fastcore.fast.ai/basics.html#store_attr) for more detail.\n",
     "\n",
     "P.S. you might be thinking that Python [dataclasses](https://docs.python.org/3/library/dataclasses.html) also allow you to avoid this boilerplate.  While true in some cases, `store_attr` is more flexible.{% fn 1 %}\n",
     "\n",
@@ -679,7 +679,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[fastcore.utils.partialler](https://fastcore.fast.ai/utils.html#partialler) fixes this, and makes sure the docstring is retained such that the new API is transparent:"
+    "[fastcore.utils.partialler](https://fastcore.fast.ai/basics.html#partialler) fixes this, and makes sure the docstring is retained such that the new API is transparent:"
    ]
   },
   {
@@ -784,7 +784,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more information about `compose`, read [the docs](https://fastcore.fast.ai/utils.html#compose).\n",
+    "For more information about `compose`, read [the docs](https://fastcore.fast.ai/basics.html#compose).\n",
     "\n",
     "---"
    ]
@@ -825,7 +825,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can use [basic_repr](https://fastcore.fast.ai/utils.html#basic_repr) to quickly give us a more sensible default:"
+    "We can use [basic_repr](https://fastcore.fast.ai/basics.html#basic_repr) to quickly give us a more sensible default:"
    ]
   },
   {
@@ -919,7 +919,7 @@
     "\n",
     "## A better pathlib.Path\n",
     "\n",
-    "When you see [these extensions](https://fastcore.fast.ai/utils.html#Extensions-to-Pathlib.Path) to pathlib.path you won't ever use vanilla pathlib again! A number of additional methods have been added to pathlib, such as:\n",
+    "When you see [these extensions](https://fastcore.fast.ai/xtras.html#Extensions-to-Pathlib.Path) to pathlib.path you won't ever use vanilla pathlib again! A number of additional methods have been added to pathlib, such as:\n",
     "\n",
     "- `Path.readlines`: same as `with open('somefile', 'r') as f: f.readlines()`\n",
     "- `Path.read`: same as `with open('somefile', 'r') as f: f.read()`\n",
@@ -928,7 +928,7 @@
     "- `Path.ls`: shows the contents of the path as a list. \n",
     "- etc.\n",
     "\n",
-    "[Read more about this here](https://fastcore.fast.ai/utils.html#Extensions-to-Pathlib.Path).  Here is a demonstration of `ls`: "
+    "[Read more about this here](https://fastcore.fast.ai/xtras.html#Extensions-to-Pathlib.Path).  Here is a demonstration of `ls`: "
    ]
   },
   {
@@ -1109,7 +1109,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Read more about `Self` in [the docs](https://fastcore.fast.ai/utils.html#Self-(with-an-uppercase-S))."
+    "Read more about `Self` in [the docs](https://fastcore.fast.ai/basics.html#Self-(with-an-uppercase-S))."
    ]
   },
   {
@@ -1292,19 +1292,19 @@
     "\n",
     "## Utilities\n",
     "\n",
-    "The [Utilites](https://fastcore.fast.ai/utils.html) section contain many shortcuts to perform common tasks or provide an additional interface to what standard python provides. \n",
+    "The [Basics](https://fastcore.fast.ai/basics.html) section contain many shortcuts to perform common tasks or provide an additional interface to what standard python provides. \n",
     "\n",
-    "- [mk_class](https://fastcore.fast.ai/utils.html#mk_class): quickly add a bunch of attributes to a class\n",
-    "- [wrap_class](https://fastcore.fast.ai/utils.html#wrap_class): add new methods to a class with a simple decorator\n",
-    "- [groupby](https://fastcore.fast.ai/utils.html#groupby): similar to Scala's groupby\n",
-    "- [merge](https://fastcore.fast.ai/utils.html#merge): merge dicts\n",
-    "- [fasttuple](https://fastcore.fast.ai/utils.html#fastuple): a tuple on steroids\n",
-    "- [Infinite Lists](https://fastcore.fast.ai/utils.html#Infinite-Lists): useful for padding and testing\n",
-    "- [chunked](https://fastcore.fast.ai/utils.html#chunked): for batching and organizing stuff\n",
+    "- [mk_class](https://fastcore.fast.ai/basics.html#mk_class): quickly add a bunch of attributes to a class\n",
+    "- [wrap_class](https://fastcore.fast.ai/basics.html#wrap_class): add new methods to a class with a simple decorator\n",
+    "- [groupby](https://fastcore.fast.ai/basics.html#groupby): similar to Scala's groupby\n",
+    "- [merge](https://fastcore.fast.ai/basics.html#merge): merge dicts\n",
+    "- [fasttuple](https://fastcore.fast.ai/basics.html#fastuple): a tuple on steroids\n",
+    "- [Infinite Lists](https://fastcore.fast.ai/basics.html#Infinite-Lists): useful for padding and testing\n",
+    "- [chunked](https://fastcore.fast.ai/basics.html#chunked): for batching and organizing stuff\n",
     "\n",
     "## Multiprocessing\n",
     "\n",
-    "The [Multiprocessing section](http://fastcore.fast.ai/utils.html#Multiprocessing) extends python's multiprocessing library by offering features like:\n",
+    "The [Multiprocessing section](http://fastcore.fast.ai/xtras.html#Multiprocessing) extends python's multiprocessing library by offering features like:\n",
     "\n",
     "- progress bars\n",
     "- ability to pause to mitigate race conditions with external services\n",
@@ -1312,11 +1312,11 @@
     "\n",
     "## Functional Programming\n",
     "\n",
-    "The [functional programming section](http://fastcore.fast.ai/utils.html#Functions-on-Functions) is my favorite part of this library.  \n",
+    "The [functional programming section](https://fastcore.fast.ai/basics.html#Functions-on-Functions) is my favorite part of this library.  \n",
     "\n",
-    "- [maps](https://fastcore.fast.ai/utils.html#maps):  a map that also composes functions\n",
-    "- [mapped](https://fastcore.fast.ai/utils.html#mapped): A more robust `map` \n",
-    "- [using_attr](https://fastcore.fast.ai/utils.html#using_attr):  compose a function that operates on an attribute\n",
+    "- [maps](https://fastcore.fast.ai/basics.html#maps):  a map that also composes functions\n",
+    "- [mapped](https://fastcore.fast.ai/xtras.html#mapped): A more robust `map` \n",
+    "- [using_attr](https://fastcore.fast.ai/basics.html#using_attr):  compose a function that operates on an attribute\n",
     "\n",
     "## Transforms\n",
     "\n",


### PR DESCRIPTION
Very small change, while reading the fastcore intro I noticed that a few of the links were outdated as the pages/sections they referred to had moved.

Not sure if I got all of the changes but I updated the ones I could find.