### PR TITLE
Disable making all file executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,4 +50,4 @@ restart-jekyll: .FORCE
 	docker-compose restart jekyll
 
 .FORCE:
-	chmod -R u+rwx .
+	chmod -R u+rw .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,5 +41,4 @@ services:
     volumes:
       - .:/data/
     command: >
-      bash -c "chmod -R u+rwx . && jekyll serve --host 0.0.0.0 --trace --strict_front_matter"
-
+      bash -c "chmod -R u+rw . && jekyll serve --host 0.0.0.0 --trace --strict_front_matter"


### PR DESCRIPTION
All files should not be made executable by default. 

Right now in local dev after run `make server` for the first time permissions of all files got changed resulting in a large `git diff`

<img width="572" alt="Screenshot 2020-11-26 at 6 36 23 PM" src="https://user-images.githubusercontent.com/6521018/100340745-9b6da500-3016-11eb-856f-246a5c426c7d.png">

that are all like this

```sh
diff --git a/.github/workflows/check_config.yaml b/.github/workflows/check_config.yaml
old mode 100644
new mode 100755
```