### PR TITLE
Add collapse-output

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ You may want some code to be hidden in a collapsed element that the user can exp
 
 - To include code in a collapsable cell that **is collapsed by default**, place the comment `#collapse` at the top of the code cell.
 - To include code in a collapsable cell that **is open by default**, place the comment `#collapse_show` or `#collapse-show` at the top of the code cell.
+- To include the output under a collapsable element that is closed by default, place the comment `#collapse_output` or `#collapse-output` at the top of the code cell.
 
 ### Embedded Twitter and YouTube Content
 In a markdown cell in your notebook, use the following markdown shortcuts to embed Twitter cards and YouTube Videos.

--- a/_action_files/hide.tpl
+++ b/_action_files/hide.tpl
@@ -24,7 +24,12 @@
 {% endblock input_group %}
 
 {% block output_group -%}
-{%- if cell.metadata.hide_output -%}
+{%- if cell.metadata.collapse_output -%}
+    <details class="description">
+      <summary class="btn btn-sm" data-open="Hide Output" data-close="Show Output"></summary>
+        <p>{{ super() }}</p>
+    </details>
+{%- elif cell.metadata.hide_output -%}
 {%- else -%}
     {{ super()  }}
 {%- endif -%}

--- a/_notebooks/2020-02-20-test.ipynb
+++ b/_notebooks/2020-02-20-test.ipynb
@@ -128,6 +128,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "place a `#collapse-output` flag at the top of any cell if you want to put the output under a collapsable element that is closed by default, but give the reader the option to open it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The comment #collapse-output was used to collapse the output of this cell by default but you can expand it.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#collapse-output\n",
+    "print('The comment #collapse-output was used to collapse the output of this cell by default but you can expand it.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Interactive Charts With Altair\n",
     "\n",
     "Charts made with Altair remain interactive.  Example charts taken from [this repo](https://github.com/uwdata/visualization-curriculum), specifically [this notebook](https://github.com/uwdata/visualization-curriculum/blob/master/altair_interaction.ipynb)."
@@ -135,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -227,7 +252,7 @@
        "alt.Chart(...)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -262,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -323,7 +348,7 @@
        "alt.Chart(...)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -351,7 +376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "scrolled": true
    },
@@ -414,7 +439,7 @@
        "alt.LayerChart(...)"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -476,7 +501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -580,7 +605,7 @@
        "4           R          3.4                    62.0  "
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Enable `#collapse-output`/`#collapse_output` from `nbdev` to place output under a collapsible element. Might be useful in situations where output is too large but still useful to show, or in assignments/quizzes where answers are shown in the outputs.

Thanks for developing this tool btw. I was looking for something exactly like this. Been using for couple of days and it's been a blast.