### PR TITLE
Install libs required to run demo locally

### DIFF
--- a/_notebooks/2020-02-21-introducing-fastpages.ipynb
+++ b/_notebooks/2020-02-21-introducing-fastpages.ipynb
@@ -119,6 +119,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "!pip install pandas altair"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
Closes #470 

This PR adds a cell to the top of the code section to install the `pandas` & `altair` libraries required to run the examples and successfully build the pages.

I have used `#hide` in the cell to prevent the `pip install` output from rendering in the corresponding Jekyll post.

/cc @hamelsmu 