### PR TITLE
change google analytics script

### DIFF
--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -2,5 +2,14 @@
 
 {% if site.google_analytics %}
 
-<script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');ga('create','{{site.google_analytics}}','auto');ga('require','displayfeatures');ga('send','pageview');</script>
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{site.google_analytics}}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{site.google_analytics}}');
+</script>
+
 {% endif %}


### PR DESCRIPTION
My understanding is that the current Google Analytics script only works with Universal Analytics tags. Google introduced a new generation of analytics known as Google Analytics 4 and I think the current script doesn't work with these types of tags. I have updated the script based on the example JavaScript Google provides when I create a Google Analytics 4 property. The script is also similar when I manually create a Universal Analytics property, so it should be backwards-compatible with those using Universal Analytics. 

Let me know if there are any issues or if you have any questions, @hamelsmu.