### PR TITLE
Fix minor whitespace issues in 2020-09-01-fastcore.ipynb, 

### DIFF
--- a/_notebooks/2020-09-01-fastcore.ipynb
+++ b/_notebooks/2020-09-01-fastcore.ipynb
@@ -186,7 +186,7 @@
     }
    ],
    "source": [
-    "def baz(a, b=2, c =3, d=4): return a + b + c\n",
+    "def baz(a, b=2, c=3, d=4): return a + b + c\n",
     "\n",
     "def foo(c, a, **kwargs):\n",
     "    return c + baz(a, **kwargs)\n",
@@ -218,7 +218,7 @@
     }
    ],
    "source": [
-    "def baz(a, b=2, c =3, d=4): return a + b + c\n",
+    "def baz(a, b=2, c=3, d=4): return a + b + c\n",
     "\n",
     "@delegates(baz) # this decorator will pass down keyword arguments from baz\n",
     "def foo(c, a, **kwargs):\n",
@@ -282,9 +282,9 @@
     }
    ],
    "source": [
-    "def basefoo(a, b=2, c =3, d=4): pass\n",
+    "def basefoo(a, b=2, c=3, d=4): pass\n",
     "\n",
-    "@delegates(basefoo, but= ['d']) # exclude `d`\n",
+    "@delegates(basefoo, but=['d']) # exclude `d`\n",
     "def foo(c, a, **kwargs): pass\n",
     "\n",
     "inspect.signature(foo)"


### PR DESCRIPTION
Removed extraneous spaces in keyword argument assignments.