### PR TITLE
Bump rexml from 3.2.4 to 3.2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rouge (3.23.0)
     rubyzip (2.3.0)
     safe_yaml (1.0.5)


### PR DESCRIPTION
Bump rexml from 3.2.4 to 3.2.5

This issue is related to https://github.com/fastai/fastpages/pull/518