### PR TITLE
Fix the youtube embed for smaller screens #358

### DIFF
--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -4,6 +4,6 @@
     {% assign url = include.content | remove: "</a>" | split: ">" | last %}
     {% assign base_url = url |  split: "/" | last %}
 {% endif %}
-<center>
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/{{base_url}}" frameborder="0" allowfullscreen></iframe>
+<center class="youtube-iframe-wrapper">
+    <iframe width="730" height="315" src="https://www.youtube.com/embed/{{base_url}}" frameborder="0" allowfullscreen></iframe>
 </center>

--- a/_sass/minima/fastpages-styles.scss
+++ b/_sass/minima/fastpages-styles.scss
@@ -256,3 +256,21 @@ table {
 pre code {
   font-size: 15px !important;
 }
+
+// Handle youtube videos, so they dont break on mobile devices
+.youtube-iframe-wrapper {
+  position: relative;
+  padding-bottom: 56.10%;
+  height: 0;
+  overflow: hidden;
+}
+
+.youtube-iframe-wrapper iframe,
+.youtube-iframe-wrapper object,
+.youtube-iframe-wrapper embed {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
Just a quick fix for the issue #358. 
Implemented solution from [here](https://www.probewise.com/blog/iframe-responsive-youtube-embed/).