### PR TITLE
Fix badges on notebook posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -45,7 +45,7 @@ layout: default
 
     {% if page.layout == 'notebook' %}
       {% if page.badges or page.badges == nil %}
-        <div class="pb-5 d-flex flex-wrap flex-justify-end">
+        <div class="pb-5 d-flex flex-justify-center">
           {% unless page.hide_github_badge or site.default_badges.github != true %}{% include notebook_github_link.html %}{% endunless %}
           {% unless page.hide_binder_badge or site.default_badges.binder != true  %}{% include notebook_binder_link.html %}{% endunless %}
           {% unless page.hide_colab_badge or site.default_badges.colab != true %}{% include notebook_colab_link.html %}{% endunless %}


### PR DESCRIPTION
Fix Badges on notebook posts to look pretty and centered on mobile.

**Before Fix:** badges wrapped and smushed against each other to the right.

**After Fix:** badges keep spacing and align in the center of the post, badges resize to suit.