### PR TITLE
Pin pyaml

### DIFF
--- a/.github/workflows/upgrade.yaml
+++ b/.github/workflows/upgrade.yaml
@@ -130,7 +130,7 @@ jobs:
         cp -r .github ../current_files
         
         # install dependencies
-        pip3 install pyyaml
+        pip3 install pyyaml==5.4.1
 
     - name: sync baseurl
       if: steps.check_version.outputs.vbump == 'true'


### PR DESCRIPTION
If we don't pin pyaml, people cannot upgrade.  The latest version of pyaml makes a breaking change and folks will get the error `TypeError: load() missing 1 required positional argument: 'Loader'`, this is my mistake as I should have pinned this dependency. 

Unfortunately, I cannot propagate this fix easily to all fastpages users.  This will only fix the issue for new users, which is one of the flaws of fastpages, as certain files like this are permanently "vendored" in without a clean way to upgrade them, since this is the file that drives the upgrading

cc: @tmabraham 