### PR TITLE
fix yaml.load in upgrade action

### DIFF
--- a/.github/workflows/upgrade.yaml
+++ b/.github/workflows/upgrade.yaml
@@ -136,6 +136,7 @@ jobs:
       if: steps.check_version.outputs.vbump == 'true'
       run: |
         import re, os, yaml
+        from yaml import Loader
         from pathlib import Path
         from configparser import ConfigParser
         settings = ConfigParser()
@@ -156,7 +157,7 @@ jobs:
         # read data from config files
         settings.read(settings_path)
         with open(config_path, 'r') as cfg:
-          config = yaml.load(cfg)
+          config = yaml.load(cfg, Loader=Loader)
         
         # sync value for baseurl b/w config.yml and settings.ini
         settings['DEFAULT']['baseurl'] = config['baseurl']


### PR DESCRIPTION
Currently, the upgrade action fails for me with the following error:

```
Run import re, os, yaml
Traceback (most recent call last):
  File "/home/runner/work/_temp/7a47792d-0b69-47f9-9572-afc4337b8a1d.py", line 22, in <module>
    config = yaml.load(cfg)
TypeError: load() missing 1 required positional argument: 'Loader'
Error: Process completed with exit code 1.
```

See the broken GitHub action in my blog: https://github.com/stefanbschneider/blog/runs/4387836262?check_suite_focus=true#step:7:40

According to the PyYaml docs, we need to specify a loader: https://pyyaml.org/wiki/PyYAMLDocumentation
That's what I did in this PR.