### PR TITLE
Suggest setup instruction by changed Github Action Policy

### DIFF
--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -1,6 +1,11 @@
 name: Setup
 on: push
 
+permissions: 
+  actions: write
+  pull-requests: write
+  contents: write
+
 jobs:
   setup:
     if: (github.event.commits[0].message == 'Initial commit') && (github.run_number == 1)

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   setup:
-    if: (github.event.commits[0].message == 'Initial commit') && (github.run_number == 1)
+    if: (github.event.commits[0].message == 'Setup commit')
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
### Abstract

As #640 reported, when user copy this template github action: Setup doesn't work. According to action log, `github-action[bot]` restrict it, I guess.

22.01 Github Policy changed so that github-action [bot] banned PR creation by Github Action. 
- [GitHub Actions: Prevent GitHub Actions from creating and approving pull requests](https://github.blog/changelog/2022-05-03-github-actions-prevent-github-actions-from-creating-and-approving-pull-requests/)
- [GitHub Actions: Prevent GitHub Actions from approving pull requests](https://github.blog/changelog/2022-01-14-github-actions-prevent-github-actions-from-approving-pull-requests/)

<details>
<summary> <i> Here is what i tried </I> </summary>

Added several [permission](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) at `Setup.yaml` file.

Unfortunately, it didn't work. Action log below is my final work.
> [setup](https://github.com/4923/archive/runs/6413494476?check_suite_focus=true)
GitHub Actions is not permitted to create or approve pull requests.

</details>

### Therefore, I suggest New Setup Instruction.

0. Add permission code at setup.yaml (f272cfe81cd0b44f24f30317e9738fc7658a715d)
1. User: Allow permission 'Allow GitHub Actions to create and approve pull requests' at repository settings/Actions/general2. 

| repo settings / Actions / General | Allow to create PR|
| :-: | :-: |
| ![repo settings](https://user-images.githubusercontent.com/60145951/168186873-2abd0a71-6254-4092-968e-1f4a26da2fa4.png)|![Allow to create PR](https://user-images.githubusercontent.com/60145951/168186928-aacc6b1f-59e0-47ef-87b9-73448a95c2b0.png)|

2. User: Commit anything but commit message should be "Setup commit"
3. User: Follow Setup PR guide / fastpages: Run setup Github Action

### Discussion
Opening PR automatically is surely represent what 'fastpages' means, for now, I'm not sure how to bypass github-action[bot]. If anyone have a better idea, let's discuss about it. How can we skip 'Allow Github Action to create and approve pull requests' step? 🤔 